### PR TITLE
Available operations update

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,7 +2,7 @@
 /* eslint-disable no-unused-vars */
 /* eslint-disable spaced-comment */
 /* eslint-disable react/prop-types */
-import React from 'react';
+import React, { useState } from 'react';
 import './App.css';
 import { withAuthenticator, Button, Heading } from '@aws-amplify/ui-react';
 // eslint-disable-next-line import/no-unresolved
@@ -25,6 +25,9 @@ const styles = {
 };
 
 function App({ signOut, user }) {
+  // todo: is this the correct place for this? where to put it??
+  const [isConnectedToAWS, setIsConnectedToAWS] = useState(false);
+
   return (
     <div id="page" style={{ outline: '1px solid black', display: 'flex', flexDirection: 'column' }}>
       <div
@@ -70,7 +73,7 @@ function App({ signOut, user }) {
                 outline: '1px solid black', backgroundColor: 'lightblue', display: 'flex', flexDirection: 'column',
               }}
             >
-              <AvailableOperations />
+              <AvailableOperations isConnected={isConnectedToAWS} />
               <p>Select an action</p>
               <Button
                 style={styles.button}
@@ -93,7 +96,7 @@ function App({ signOut, user }) {
             </div>
           </div>
           <div id="right" style={{ outline: '1px solid black', flexDirection: 'row' }}>
-            <AWS />
+            <AWS setIsConnected={setIsConnectedToAWS} />
             <button type="button" onClick={() => utils.publish(topics.hubbleCommandReq, payloads.hubbleEchoCommand)}>Echo Hello</button>
           </div>
         </div>

--- a/src/app/aws/AWS.jsx
+++ b/src/app/aws/AWS.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Amplify } from 'aws-amplify';
+import PropTypes from 'prop-types';
 import awsExports from '../../aws-exports';
 import * as utils from '../utils/utils';
 import * as topics from '../utils/topics';
@@ -18,7 +19,7 @@ utils.displayAuthStateChanges();
 // need this to keep the connection open
 utils.subscribe(topics.hubbleCommandRes, utils.printData);
 
-function AWS() {
+function AWS({ setIsConnected }) {
   const deviceStatuses = [
     { deviceId: 'Hubble', deviceName: 'Hubble' },
     { deviceId: 'Krib', deviceName: 'Krib' },
@@ -26,7 +27,7 @@ function AWS() {
 
   return (
     <>
-      <ConnectionStatus />
+      <ConnectionStatus setIsConnected={setIsConnected} />
       <h2>AWS Stuff</h2>
       <ActiveSubscriptions />
       <h3>IoT Devices:</h3>
@@ -43,5 +44,9 @@ function AWS() {
     </>
   );
 }
+
+AWS.propTypes = {
+  setIsConnected: PropTypes.func.isRequired,
+};
 
 export default AWS;

--- a/src/app/aws/AWS.jsx
+++ b/src/app/aws/AWS.jsx
@@ -31,7 +31,13 @@ function AWS() {
       <ActiveSubscriptions />
       <h3>IoT Devices:</h3>
       {deviceStatuses.map(
-        (device) => <DeviceStatus deviceId={device.deviceId} deviceName={device.deviceName} />,
+        (device) => (
+          <DeviceStatus
+            key={device.deviceId}
+            deviceId={device.deviceId}
+            deviceName={device.deviceName}
+          />
+        ),
       )}
       <Log />
     </>

--- a/src/app/aws/AvailableOperations.jsx
+++ b/src/app/aws/AvailableOperations.jsx
@@ -1,24 +1,39 @@
 import React, { useEffect, useState } from 'react';
-import { Button } from '@aws-amplify/ui-react';
-import { subscribe, requestHubbleOperations, addEntryToLog } from '../utils/utils';
+import { subscribe, addEntryToLog, requestHubbleOperations } from '../utils/utils';
 import { resHubbleOperations } from '../utils/topics';
+
+/*
+When to get available operations?
+1. On startup
+2. On publish to "operations ready for query" topic
+    Or just subscribe and make sure Neo publishes on startup
+      That's way easier
+*/
 
 function AvailableOperations() {
   const [operations, setOperations] = useState([]);
 
+  // subscribe to operations response
   useEffect(() => {
-    // 1. Subscribe to operations channel
     setOperations([]);
     // eslint-disable-next-line no-unused-vars
     subscribe(resHubbleOperations, (d, t) => {
-      const obj = JSON.parse(d.value).res;
+      const obj = JSON.parse(d.value).res; // todo: take out res?
       setOperations(obj);
       addEntryToLog('Received Hubble Operations');
     });
   }, []);
+  // publish to request operations
+  useEffect(() => {
+    // set timeout because connection status??
+    setTimeout(() => {
+      requestHubbleOperations();
+    }, 2000); // todo: wait for active connection
+  }, []);
+
   return (
     <div>
-      <Button onClick={requestHubbleOperations}>Get Available Operations</Button>
+      <h3>Available Operations</h3>
       <ul>
         {operations.map((opr, idx) => (
           // eslint-disable-next-line react/no-array-index-key

--- a/src/app/aws/AvailableOperations.jsx
+++ b/src/app/aws/AvailableOperations.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
 import { subscribe, addEntryToLog, requestHubbleOperations } from '../utils/utils';
 import { resHubbleOperations } from '../utils/topics';
 
@@ -10,7 +11,7 @@ When to get available operations?
       That's way easier
 */
 
-function AvailableOperations() {
+function AvailableOperations({ isConnected }) {
   const [operations, setOperations] = useState([]);
 
   // subscribe to operations response
@@ -25,11 +26,9 @@ function AvailableOperations() {
   }, []);
   // publish to request operations
   useEffect(() => {
-    // set timeout because connection status??
-    setTimeout(() => {
-      requestHubbleOperations();
-    }, 2000); // todo: wait for active connection
-  }, []);
+    addEntryToLog('Connected: Requesting Hubble Operations');
+    if (isConnected) { requestHubbleOperations(); }
+  }, [isConnected]);
 
   return (
     <div>
@@ -47,5 +46,9 @@ function AvailableOperations() {
     </div>
   );
 }
+
+AvailableOperations.propTypes = {
+  isConnected: PropTypes.bool.isRequired,
+};
 
 export default AvailableOperations;

--- a/src/app/aws/ConnectionStatus.jsx
+++ b/src/app/aws/ConnectionStatus.jsx
@@ -4,6 +4,7 @@
 /* eslint-disable no-trailing-spaces */
 /* eslint-disable no-unused-vars */
 import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
 import Chip from '@mui/material/Chip';
 import { 
   green, 
@@ -14,9 +15,9 @@ import {
 } from '@mui/material/colors';
 import { Hub } from 'aws-amplify';
 import { CONNECTION_STATE_CHANGE } from '@aws-amplify/pubsub';
-import { SvgIcon } from '@mui/material';
+import { addEntryToLog } from '../utils/utils';
 
-function ConnectionStatus() {
+function ConnectionStatus({ setIsConnected }) {
   const colorDefault = blueGrey;
   const colorMap = {
     Connected: green, // Connected and working with no issues.
@@ -40,6 +41,8 @@ function ConnectionStatus() {
         const newState = payload.data.connectionState;
         setConnectionState(newState);
         setConnectionColor(colorMap[newState]);
+        addEntryToLog('ConnectionState:', newState);
+        setIsConnected(newState === 'Connected');
       }
     });   
   }, [connectionState, connectionColor]);
@@ -52,5 +55,9 @@ function ConnectionStatus() {
     </div>
   );
 }
+
+ConnectionStatus.propTypes = {
+  setIsConnected: PropTypes.func.isRequired,
+};
 
 export default ConnectionStatus;


### PR DESCRIPTION
Before, available operations were queried at the push of a button. This worked for initial setup, but is not the intended solution. Upon requesting available operations at startup, the request was published before this device had been activated, so it didn't "go anywhere". Now, the application waits until the connection has been initialized to publish this request. 

Before this solution, available operations worked if Neo was started after Dibiasky because it would publish to the available operations topic upon startup. Now, it also works if Neo is started first.